### PR TITLE
Better symbol<>token match for saturn

### DIFF
--- a/exchanges/Saturn.js
+++ b/exchanges/Saturn.js
@@ -29,7 +29,7 @@ module.exports = class SaturnNetwork extends OrderBookExchange {
 
   async _getTokenAddress(symbol) {
     const allTokens = await this._getCurrencies()
-    const tokenObj = allTokens.find(x => x.token.symbol === symbol)
+    const tokenObj = allTokens.find(x => x.token.symbol.toLowerCase() === symbol.toLowerCase())
     return tokenObj.token.address
   }
 


### PR DESCRIPTION
Noticed that some tokens with *weird* symbols, such as `0xBTC`, do not get properly shown on dexindex because you upcase the symbol in the UI. This is a hotfix for this issue